### PR TITLE
Fix http provider for absolute urls

### DIFF
--- a/app/modules/cs_common/scripts/cs_http_options_provider.js
+++ b/app/modules/cs_common/scripts/cs_http_options_provider.js
@@ -69,7 +69,7 @@ define(['angular', '../module'], function (ng) {
        * Interceptor.
        *
        * Add the domain to all the HTTP requests that are not
-       * templates.
+       * templates. And doesn't add it to absolute urls.
        *
        * Note: Hookup the $templates service to get the proper
        * regex. This works for now as is what we are using.
@@ -77,7 +77,7 @@ define(['angular', '../module'], function (ng) {
       $httpProvider.interceptors.push(function () {
         return {
           request: function (config) {
-            if(! /views\/(.*).html$/.test(config.url)) {
+            if( ! /views\/(.*).html$/.test( config.url ) && ! /^(http|https:\/\/)/i.test( config.url ) ) {
               config.url = domain + config.url;
             }
             return config;


### PR DESCRIPTION
$httpProvider intercepror won't add domain prefix for absolute urls that starts from: `http://` or `https://`.

Screenshots:
- before: http://d.pr/i/TWJe
- after: http://d.pr/i/Yqrc
