### PR TITLE
Modified protractor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-script-launcher": "~0.1.0",
     "load-grunt-tasks": "~0.2.0",
     "phantomjs": "~1.9.2",
-    "protractor": "latest",
+    "protractor": "~0.10.0",
     "time-grunt": "~0.2.1"
   },
   "engines": {


### PR DESCRIPTION
Protractor version "latest" was causing the following error when installing using `clever init <package>`:

```
npm ERR! peerinvalid The package protractor does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-protractor-runner@0.1.11 wants protractor@>=0.10.0-0 <1.0.0

npm ERR! System Linux 3.5.0-17-generic
npm ERR! command "/home/lucas/.local/bin/node" "/home/lucas/.local/bin/npm" "install"
npm ERR! cwd /home/lucas/app-name
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.3
npm ERR! code EPEERINVALID
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/lucas/app-name/npm-debug.log
npm ERR! not ok code 0
```

Changing the dependency version to one that matched _grunt-protractor-runner_ needs - in this case, **~0.10.0** - seem to have fixed the problem.

Anyway, in most cases we shouldn't depend on a _latest_ version, as this will probably cause incompatibility at some point in the future.
